### PR TITLE
:whale: Use base image as argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM jupyter/base-notebook:python-3.7.6
-
+ARG BASE_IMAGE=jupyter/base-notebook:python-3.7.6
+FROM ${BASE_IMAGE}
 
 USER root
 


### PR DESCRIPTION
In this pull request, the Dockerfile was changed in order to use the base image as an argument when building the image.